### PR TITLE
Increase pronoun box max-width to allow `They/Them`

### DIFF
--- a/Fate Official/FateOmni.css
+++ b/Fate Official/FateOmni.css
@@ -130,7 +130,7 @@ input[type="checkbox"].sheet-triggerbox:checked + .sheet-optbar {
 
 input.sheet-compact,
 select.sheet-compact {
-	max-width: 90px;
+	max-width: 85px;
 }
 
 input.sheet-ultracompact,
@@ -606,6 +606,7 @@ input.sheet-icon[value="blank"] + span.sheet-icon::before {
 
 .sheet-pronounbox input {
 	text-align: center;
+	max-width: 90px;
 }
 
 .sheet-Bar div {

--- a/Fate Official/FateOmni.css
+++ b/Fate Official/FateOmni.css
@@ -130,7 +130,7 @@ input[type="checkbox"].sheet-triggerbox:checked + .sheet-optbar {
 
 input.sheet-compact,
 select.sheet-compact {
-	max-width: 85px;
+	max-width: 90px;
 }
 
 input.sheet-ultracompact,


### PR DESCRIPTION
I really appreciate that there is a section on the roll20 sheet for pronouns! However, when I enter `They/Them` it's cut off and appears to be `They/Then`. This doesn't occur if I use all lower case letters, but stylistically I think upper case looks better. 
![image](https://user-images.githubusercontent.com/352979/97583108-f1760b00-19cc-11eb-8328-fd831518f794.png)

This includes an override of `max-width` for the `.sheet-pronounbox input` selector so it should have no other effects on the rest of the sheet. I set it to 90 as that fixed the issue for me, but it might make sense to increase it to support a trio of pronouns or other pronouns that may be longer.